### PR TITLE
feat: add drawer-based person form

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,13 +1,22 @@
 let people = [];
 let nextId = 1;
 
+const addBtn = document.getElementById('add-btn');
+const emptyBtn = document.getElementById('empty-btn');
+const exportBtn = document.getElementById('export-btn');
+const importBtn = document.getElementById('import-btn');
+const overlay = document.getElementById('overlay');
+const drawer = document.getElementById('drawer');
 const form = document.getElementById('person-form');
-const list = document.getElementById('people-list');
-const saveBtn = document.getElementById('save-btn');
-const openBtn = document.getElementById('open-btn');
+const cancelBtn = document.getElementById('cancel-btn');
+const tableBody = document.getElementById('people-body');
 
-form.addEventListener('submit', event => {
-  event.preventDefault();
+addBtn.addEventListener('click', openDrawer);
+cancelBtn.addEventListener('click', closeDrawer);
+overlay.addEventListener('click', closeDrawer);
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
   const data = new FormData(form);
   const person = {
     id: nextId++,
@@ -22,18 +31,15 @@ form.addEventListener('submit', event => {
   people.push(person);
   renderPeople();
   form.reset();
+  closeDrawer();
 });
 
-list.addEventListener('click', event => {
-  const button = event.target.closest('button[data-action="delete"]');
-  if (button) {
-    const id = parseInt(button.dataset.id, 10);
-    people = people.filter(p => p.id !== id);
-    renderPeople();
-  }
+emptyBtn.addEventListener('click', () => {
+  people = [];
+  renderPeople();
 });
 
-saveBtn.addEventListener('click', () => {
+exportBtn.addEventListener('click', () => {
   const blob = new Blob([JSON.stringify(people, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -43,7 +49,7 @@ saveBtn.addEventListener('click', () => {
   URL.revokeObjectURL(url);
 });
 
-openBtn.addEventListener('click', () => {
+importBtn.addEventListener('click', () => {
   const input = document.createElement('input');
   input.type = 'file';
   input.accept = 'application/json';
@@ -69,22 +75,27 @@ openBtn.addEventListener('click', () => {
 });
 
 function renderPeople() {
-  list.innerHTML = '';
+  tableBody.innerHTML = '';
   for (const person of people) {
-    const li = document.createElement('li');
-    li.className = 'p-4 flex justify-between items-center';
-    li.innerHTML = `
-      <div>
-        <p class="font-medium">${person.firstName} ${person.lastName}</p>
-        <p class="text-sm text-gray-600">ID: ${person.id}</p>
-      </div>
-      <button data-action="delete" data-id="${person.id}" class="inline-flex items-center text-red-600" aria-label="Delete person ${person.id}">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-        </svg>
-        <span class="ml-1">Delete</span>
-      </button>
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td class="px-4 py-2">${person.id}</td>
+      <td class="px-4 py-2">${person.firstName}</td>
+      <td class="px-4 py-2">${person.lastName}</td>
     `;
-    list.appendChild(li);
+    tableBody.appendChild(tr);
   }
 }
+
+function openDrawer() {
+  overlay.classList.remove('hidden');
+  drawer.classList.remove('translate-y-full');
+}
+
+function closeDrawer() {
+  overlay.classList.add('hidden');
+  drawer.classList.add('translate-y-full');
+}
+
+renderPeople();
+

--- a/web/index.html
+++ b/web/index.html
@@ -12,71 +12,102 @@
     <h1 class="text-xl font-bold">Family Tree Builder</h1>
   </header>
   <main class="p-4">
-    <section>
-      <h2 class="text-lg font-semibold mb-2">Add Person</h2>
-      <form id="person-form" class="grid gap-4 md:grid-cols-2" aria-labelledby="add-person-heading">
-        <div>
-          <label for="first-name" class="block text-sm font-medium">First Name</label>
-          <input id="first-name" name="firstName" type="text" class="mt-1 w-full rounded border-gray-300" />
-        </div>
-        <div>
-          <label for="last-name" class="block text-sm font-medium">Last Name</label>
-          <input id="last-name" name="lastName" type="text" class="mt-1 w-full rounded border-gray-300" />
-        </div>
-        <div>
-          <label for="birth-date" class="block text-sm font-medium">Birthdate</label>
-          <input id="birth-date" name="birthDate" type="text" class="mt-1 w-full rounded border-gray-300" placeholder="YYYY-MM-DD" />
-        </div>
-        <div>
-          <label for="death-date" class="block text-sm font-medium">Death</label>
-          <input id="death-date" name="deathDate" type="text" class="mt-1 w-full rounded border-gray-300" placeholder="YYYY-MM-DD" />
-        </div>
-        <div>
-          <label for="birth-place" class="block text-sm font-medium">Birth location</label>
-          <input id="birth-place" name="birthPlace" type="text" class="mt-1 w-full rounded border-gray-300" />
-        </div>
-        <div>
-          <label for="death-place" class="block text-sm font-medium">Death location</label>
-          <input id="death-place" name="deathPlace" type="text" class="mt-1 w-full rounded border-gray-300" />
-        </div>
-        <div>
-          <label for="gender" class="block text-sm font-medium">Gender</label>
-          <select id="gender" name="gender" class="mt-1 w-full rounded border-gray-300">
-            <option value="">Select</option>
-            <option value="female">Female</option>
-            <option value="male">Male</option>
-            <option value="other">Other</option>
-          </select>
-        </div>
-        <div class="flex items-end">
-          <button type="submit" class="inline-flex items-center rounded bg-green-600 px-4 py-2 text-white">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-            </svg>
-            Add Person
-          </button>
-        </div>
-      </form>
-    </section>
-    <section class="mt-8">
-      <h2 class="text-lg font-semibold mb-2">People</h2>
-      <ul id="people-list" class="divide-y divide-gray-200 bg-white rounded shadow" aria-live="polite"></ul>
-    </section>
+    <p class="mb-4">Use the buttons to manage your family tree. Start by adding a person.</p>
+    <div class="flex flex-wrap gap-2 mb-4">
+      <button id="add-btn" class="inline-flex items-center rounded bg-green-600 px-4 py-2 text-white">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+        </svg>
+        <span>Add</span>
+      </button>
+      <button id="empty-btn" class="inline-flex items-center rounded bg-red-600 px-4 py-2 text-white">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3H4m16 0h-4" />
+        </svg>
+        <span>Empty</span>
+      </button>
+      <button id="export-btn" class="inline-flex items-center rounded bg-blue-600 px-4 py-2 text-white">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v12a2 2 0 002 2h12a2 2 0 002-2V4M4 4l8 8m0 0l8-8M12 12v8" />
+        </svg>
+        <span>Export</span>
+      </button>
+      <button id="import-btn" class="inline-flex items-center rounded bg-gray-600 px-4 py-2 text-white">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v12a2 2 0 002 2h12a2 2 0 002-2V4M16 12l-4 4m0 0l-4-4m4 4V4" />
+        </svg>
+        <span>Import</span>
+      </button>
+    </div>
+    <div class="overflow-x-auto bg-white rounded shadow">
+      <table class="min-w-full text-left" aria-live="polite">
+        <thead class="bg-gray-50">
+          <tr>
+            <th scope="col" class="px-4 py-2">ID</th>
+            <th scope="col" class="px-4 py-2">First Name</th>
+            <th scope="col" class="px-4 py-2">Last Name</th>
+          </tr>
+        </thead>
+        <tbody id="people-body"></tbody>
+      </table>
+    </div>
   </main>
-  <footer class="p-4 text-center text-sm text-gray-600">
-    <button id="open-btn" class="mr-4 inline-flex items-center rounded bg-gray-200 px-4 py-2">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-      </svg>
-      Open
-    </button>
-    <button id="save-btn" class="inline-flex items-center rounded bg-gray-200 px-4 py-2">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-      </svg>
-      Save
-    </button>
-  </footer>
+
+  <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden" aria-hidden="true"></div>
+  <div id="drawer" class="drawer fixed inset-x-0 bottom-0 bg-white rounded-t-lg p-4 transform translate-y-full" role="dialog" aria-modal="true" aria-labelledby="add-person-heading">
+    <h2 id="add-person-heading" class="text-lg font-semibold mb-4">Add Person</h2>
+    <form id="person-form" class="grid gap-4 md:grid-cols-2">
+      <div>
+        <label for="first-name" class="block text-sm font-medium">First Name</label>
+        <input id="first-name" name="firstName" type="text" class="mt-1 w-full rounded border-gray-300" />
+      </div>
+      <div>
+        <label for="last-name" class="block text-sm font-medium">Last Name</label>
+        <input id="last-name" name="lastName" type="text" class="mt-1 w-full rounded border-gray-300" />
+      </div>
+      <div>
+        <label for="birth-date" class="block text-sm font-medium">Birthdate</label>
+        <input id="birth-date" name="birthDate" type="text" class="mt-1 w-full rounded border-gray-300" placeholder="YYYY-MM-DD" />
+      </div>
+      <div>
+        <label for="death-date" class="block text-sm font-medium">Death</label>
+        <input id="death-date" name="deathDate" type="text" class="mt-1 w-full rounded border-gray-300" placeholder="YYYY-MM-DD" />
+      </div>
+      <div>
+        <label for="birth-place" class="block text-sm font-medium">Birth location</label>
+        <input id="birth-place" name="birthPlace" type="text" class="mt-1 w-full rounded border-gray-300" />
+      </div>
+      <div>
+        <label for="death-place" class="block text-sm font-medium">Death location</label>
+        <input id="death-place" name="deathPlace" type="text" class="mt-1 w-full rounded border-gray-300" />
+      </div>
+      <div>
+        <label for="gender" class="block text-sm font-medium">Gender</label>
+        <select id="gender" name="gender" class="mt-1 w-full rounded border-gray-300">
+          <option value="">Select</option>
+          <option value="female">Female</option>
+          <option value="male">Male</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+      <div class="md:col-span-2 flex justify-end space-x-2">
+        <button type="button" id="cancel-btn" class="inline-flex items-center rounded bg-gray-200 px-4 py-2">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+          <span>Cancel</span>
+        </button>
+        <button type="submit" class="inline-flex items-center rounded bg-green-600 px-4 py-2 text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+          <span>Save</span>
+        </button>
+      </div>
+    </form>
+  </div>
+
   <script src="app.js"></script>
 </body>
 </html>
+

--- a/web/style.css
+++ b/web/style.css
@@ -1,1 +1,4 @@
 /* Custom styles for Family Tree Builder */
+.drawer {
+  transition: transform 0.3s ease-in-out;
+}


### PR DESCRIPTION
## Summary
- show instructions with Add/Empty/Export/Import controls and empty table
- slide-up drawer for adding people with dimmed backdrop
- export, import and empty actions manage table contents

## Testing
- `npm test` (fails: Could not read package.json)
- `npx prettier --check web/index.html web/app.js web/style.css`

------
https://chatgpt.com/codex/tasks/task_e_688e60fe510c8331bbe089c353531c7c