### PR TITLE
Fix Add button initialization and Tailwind warning

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1,101 +1,103 @@
 let people = [];
 let nextId = 1;
 
-const addBtn = document.getElementById('add-btn');
-const emptyBtn = document.getElementById('empty-btn');
-const exportBtn = document.getElementById('export-btn');
-const importBtn = document.getElementById('import-btn');
-const overlay = document.getElementById('overlay');
-const drawer = document.getElementById('drawer');
-const form = document.getElementById('person-form');
-const cancelBtn = document.getElementById('cancel-btn');
-const tableBody = document.getElementById('people-body');
+document.addEventListener('DOMContentLoaded', () => {
+  const addBtn = document.getElementById('add-btn');
+  const emptyBtn = document.getElementById('empty-btn');
+  const exportBtn = document.getElementById('export-btn');
+  const importBtn = document.getElementById('import-btn');
+  const overlay = document.getElementById('overlay');
+  const drawer = document.getElementById('drawer');
+  const form = document.getElementById('person-form');
+  const cancelBtn = document.getElementById('cancel-btn');
+  const tableBody = document.getElementById('people-body');
 
-addBtn.addEventListener('click', openDrawer);
-cancelBtn.addEventListener('click', closeDrawer);
-overlay.addEventListener('click', closeDrawer);
-
-form.addEventListener('submit', e => {
-  e.preventDefault();
-  const data = new FormData(form);
-  const person = {
-    id: nextId++,
-    firstName: data.get('firstName') || '',
-    lastName: data.get('lastName') || '',
-    birthDate: data.get('birthDate') || '',
-    deathDate: data.get('deathDate') || '',
-    birthPlace: data.get('birthPlace') || '',
-    deathPlace: data.get('deathPlace') || '',
-    gender: data.get('gender') || ''
-  };
-  people.push(person);
-  renderPeople();
-  form.reset();
-  closeDrawer();
-});
-
-emptyBtn.addEventListener('click', () => {
-  people = [];
-  renderPeople();
-});
-
-exportBtn.addEventListener('click', () => {
-  const blob = new Blob([JSON.stringify(people, null, 2)], { type: 'application/json' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'family.json';
-  a.click();
-  URL.revokeObjectURL(url);
-});
-
-importBtn.addEventListener('click', () => {
-  const input = document.createElement('input');
-  input.type = 'file';
-  input.accept = 'application/json';
-  input.onchange = e => {
-    const file = e.target.files[0];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = ev => {
-      try {
-        const data = JSON.parse(ev.target.result);
-        if (Array.isArray(data)) {
-          people = data;
-          nextId = data.reduce((max, p) => Math.max(max, p.id), 0) + 1;
-          renderPeople();
-        }
-      } catch (err) {
-        console.error('Invalid file', err);
-      }
-    };
-    reader.readAsText(file);
-  };
-  input.click();
-});
-
-function renderPeople() {
-  tableBody.innerHTML = '';
-  for (const person of people) {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `
-      <td class="px-4 py-2">${person.id}</td>
-      <td class="px-4 py-2">${person.firstName}</td>
-      <td class="px-4 py-2">${person.lastName}</td>
-    `;
-    tableBody.appendChild(tr);
+  function renderPeople() {
+    tableBody.innerHTML = '';
+    for (const person of people) {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td class="px-4 py-2">${person.id}</td>
+        <td class="px-4 py-2">${person.firstName}</td>
+        <td class="px-4 py-2">${person.lastName}</td>
+      `;
+      tableBody.appendChild(tr);
+    }
   }
-}
 
-function openDrawer() {
-  overlay.classList.remove('hidden');
-  drawer.classList.remove('translate-y-full');
-}
+  function openDrawer() {
+    overlay.classList.remove('hidden');
+    drawer.classList.remove('translate-y-full');
+  }
 
-function closeDrawer() {
-  overlay.classList.add('hidden');
-  drawer.classList.add('translate-y-full');
-}
+  function closeDrawer() {
+    overlay.classList.add('hidden');
+    drawer.classList.add('translate-y-full');
+  }
 
-renderPeople();
+  addBtn.addEventListener('click', openDrawer);
+  cancelBtn.addEventListener('click', closeDrawer);
+  overlay.addEventListener('click', closeDrawer);
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const data = new FormData(form);
+    const person = {
+      id: nextId++,
+      firstName: data.get('firstName') || '',
+      lastName: data.get('lastName') || '',
+      birthDate: data.get('birthDate') || '',
+      deathDate: data.get('deathDate') || '',
+      birthPlace: data.get('birthPlace') || '',
+      deathPlace: data.get('deathPlace') || '',
+      gender: data.get('gender') || ''
+    };
+    people.push(person);
+    renderPeople();
+    form.reset();
+    closeDrawer();
+  });
+
+  emptyBtn.addEventListener('click', () => {
+    people = [];
+    renderPeople();
+  });
+
+  exportBtn.addEventListener('click', () => {
+    const blob = new Blob([JSON.stringify(people, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'family.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  importBtn.addEventListener('click', () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'application/json';
+    input.onchange = e => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = ev => {
+        try {
+          const data = JSON.parse(ev.target.result);
+          if (Array.isArray(data)) {
+            people = data;
+            nextId = data.reduce((max, p) => Math.max(max, p.id), 0) + 1;
+            renderPeople();
+          }
+        } catch (err) {
+          console.error('Invalid file', err);
+        }
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  });
+
+  renderPeople();
+});
 

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Family Tree Builder</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link
+    href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css"
+    rel="stylesheet"
+  />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body class="min-h-screen bg-gray-100 text-gray-900">


### PR DESCRIPTION
## Summary
- Load Tailwind from static CSS instead of the runtime CDN script to avoid production warnings.
- Wait for `DOMContentLoaded` before wiring UI events so the Add button and other controls work reliably.

## Testing
- `node --check web/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e639862708331ba20096ee975cb27