### PR TITLE
feat: add person editing and relationships

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -13,25 +13,107 @@ document.addEventListener('DOMContentLoaded', () => {
   const tableBody = document.getElementById('people-body');
   const birthDateInput = document.getElementById('birth-date');
   const deathDateInput = document.getElementById('death-date');
+  const firstNameInput = document.getElementById('first-name');
+  const lastNameInput = document.getElementById('last-name');
+  const birthPlaceInput = document.getElementById('birth-place');
+  const deathPlaceInput = document.getElementById('death-place');
+  const genderSelect = document.getElementById('gender');
+  const parentSelect = document.getElementById('parent-id');
+  const partnerSelect = document.getElementById('partner-id');
+  const idInput = document.getElementById('person-id');
+  const heading = document.getElementById('add-person-heading');
 
   function renderPeople() {
     tableBody.innerHTML = '';
     for (const person of people) {
+      const parent = people.find(p => p.id === person.parentId);
+      const partner = people.find(p => p.id === person.partnerId);
       const tr = document.createElement('tr');
       tr.innerHTML = `
         <td class="px-4 py-2">${person.id}</td>
         <td class="px-4 py-2">${person.firstName}</td>
         <td class="px-4 py-2">${person.lastName}</td>
+        <td class="px-4 py-2">${parent ? parent.firstName + ' ' + parent.lastName : ''}</td>
+        <td class="px-4 py-2">${partner ? partner.firstName + ' ' + partner.lastName : ''}</td>
+        <td class="px-4 py-2 flex gap-1">
+          <button data-id="${person.id}" class="edit-btn inline-flex items-center rounded bg-gray-200 px-2 py-1 text-gray-800">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/>
+            </svg>
+            <span>Edit</span>
+          </button>
+          <button data-id="${person.id}" class="delete-btn inline-flex items-center rounded bg-gray-200 px-2 py-1 text-gray-800">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3H4m16 0h-4"/>
+            </svg>
+            <span>Delete</span>
+          </button>
+        </td>
       `;
       tableBody.appendChild(tr);
     }
+    tableBody.querySelectorAll('.edit-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = parseInt(btn.dataset.id, 10);
+        const person = people.find(p => p.id === id);
+        if (person) {
+          openDrawer(person);
+        }
+      });
+    });
+    tableBody.querySelectorAll('.delete-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = parseInt(btn.dataset.id, 10);
+        people = people.filter(p => p.id !== id);
+        for (const p of people) {
+          if (p.parentId === id) p.parentId = undefined;
+          if (p.partnerId === id) p.partnerId = undefined;
+        }
+        renderPeople();
+      });
+    });
   }
 
-  function openDrawer() {
+  function populateRelationshipOptions(currentId = null) {
+    parentSelect.innerHTML = '<option value="">Select</option>';
+    partnerSelect.innerHTML = '<option value="">Select</option>';
+    for (const p of people) {
+      if (p.id === currentId) continue;
+      const label = `${p.id}: ${p.lastName}, ${p.firstName} (${p.birthDate} - ${p.deathDate})`;
+      const parentOption = document.createElement('option');
+      parentOption.value = p.id;
+      parentOption.textContent = label;
+      parentSelect.appendChild(parentOption);
+      const partnerOption = document.createElement('option');
+      partnerOption.value = p.id;
+      partnerOption.textContent = label;
+      partnerSelect.appendChild(partnerOption);
+    }
+  }
+
+  function openDrawer(person = null) {
+    populateRelationshipOptions(person ? person.id : null);
+    if (person) {
+      heading.textContent = 'Edit Person';
+      idInput.value = person.id;
+      firstNameInput.value = person.firstName;
+      lastNameInput.value = person.lastName;
+      birthDateInput.value = person.birthDate;
+      deathDateInput.value = person.deathDate;
+      birthPlaceInput.value = person.birthPlace;
+      deathPlaceInput.value = person.deathPlace;
+      genderSelect.value = person.gender;
+      parentSelect.value = person.parentId || '';
+      partnerSelect.value = person.partnerId || '';
+    } else {
+      heading.textContent = 'Add Person';
+      form.reset();
+      idInput.value = '';
+    }
     overlay.classList.remove('hidden');
     overlay.setAttribute('aria-hidden', 'false');
     drawer.classList.remove('translate-y-full');
-    document.getElementById('first-name').focus();
+    firstNameInput.focus();
   }
 
   function closeDrawer() {
@@ -75,17 +157,35 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     const data = new FormData(form);
-    const person = {
-      id: nextId++,
-      firstName: data.get('firstName') || '',
-      lastName: data.get('lastName') || '',
-      birthDate: data.get('birthDate') || '',
-      deathDate: data.get('deathDate') || '',
-      birthPlace: data.get('birthPlace') || '',
-      deathPlace: data.get('deathPlace') || '',
-      gender: data.get('gender') || ''
-    };
-    people.push(person);
+    const id = data.get('id');
+    if (id) {
+      const person = people.find(p => p.id === parseInt(id, 10));
+      if (person) {
+        person.firstName = data.get('firstName') || '';
+        person.lastName = data.get('lastName') || '';
+        person.birthDate = data.get('birthDate') || '';
+        person.deathDate = data.get('deathDate') || '';
+        person.birthPlace = data.get('birthPlace') || '';
+        person.deathPlace = data.get('deathPlace') || '';
+        person.gender = data.get('gender') || '';
+        person.parentId = data.get('parentId') ? parseInt(data.get('parentId'), 10) : undefined;
+        person.partnerId = data.get('partnerId') ? parseInt(data.get('partnerId'), 10) : undefined;
+      }
+    } else {
+      const person = {
+        id: nextId++,
+        firstName: data.get('firstName') || '',
+        lastName: data.get('lastName') || '',
+        birthDate: data.get('birthDate') || '',
+        deathDate: data.get('deathDate') || '',
+        birthPlace: data.get('birthPlace') || '',
+        deathPlace: data.get('deathPlace') || '',
+        gender: data.get('gender') || '',
+        parentId: data.get('parentId') ? parseInt(data.get('parentId'), 10) : undefined,
+        partnerId: data.get('partnerId') ? parseInt(data.get('partnerId'), 10) : undefined
+      };
+      people.push(person);
+    }
     renderPeople();
     form.reset();
     closeDrawer();
@@ -93,6 +193,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   emptyBtn.addEventListener('click', () => {
     people = [];
+    nextId = 1;
     renderPeople();
   });
 

--- a/web/index.html
+++ b/web/index.html
@@ -46,6 +46,9 @@
             <th scope="col" class="px-4 py-2">ID</th>
             <th scope="col" class="px-4 py-2">First Name</th>
             <th scope="col" class="px-4 py-2">Last Name</th>
+            <th scope="col" class="px-4 py-2">Parent</th>
+            <th scope="col" class="px-4 py-2">Partner</th>
+            <th scope="col" class="px-4 py-2">Actions</th>
           </tr>
         </thead>
         <tbody id="people-body"></tbody>
@@ -57,6 +60,7 @@
   <div id="drawer" class="drawer fixed inset-x-0 bottom-0 bg-white rounded-t-lg p-4 transform translate-y-full" role="dialog" aria-modal="true" aria-labelledby="add-person-heading">
     <h2 id="add-person-heading" class="text-lg font-semibold mb-4">Add Person</h2>
     <form id="person-form" class="grid gap-4 md:grid-cols-2">
+      <input type="hidden" id="person-id" name="id" />
       <div>
         <label for="first-name" class="block text-sm font-medium">First Name</label>
         <input id="first-name" name="firstName" type="text" class="mt-1 w-full rounded border border-gray-300" minlength="1" />
@@ -88,6 +92,18 @@
           <option value="female">Female</option>
           <option value="male">Male</option>
           <option value="other">Other</option>
+        </select>
+      </div>
+      <div>
+        <label for="parent-id" class="block text-sm font-medium">Parent</label>
+        <select id="parent-id" name="parentId" class="mt-1 w-full rounded border border-gray-300">
+          <option value="">Select</option>
+        </select>
+      </div>
+      <div>
+        <label for="partner-id" class="block text-sm font-medium">Partner</label>
+        <select id="partner-id" name="partnerId" class="mt-1 w-full rounded border border-gray-300">
+          <option value="">Select</option>
         </select>
       </div>
       <div class="md:col-span-2 flex justify-end space-x-2">


### PR DESCRIPTION
## Summary
- allow editing existing people and storing parent and partner relationships
- add parent/partner columns with per-row edit and delete actions
- enable selecting related people from populated dropdowns

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e771a79048331be791219ef353961