### PR TITLE
Allow selecting two parents and rename person fields

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -44,9 +44,9 @@
         <thead class="bg-gray-50">
           <tr>
             <th scope="col" class="px-4 py-2">ID</th>
-            <th scope="col" class="px-4 py-2">First Name</th>
-            <th scope="col" class="px-4 py-2">Last Name</th>
-            <th scope="col" class="px-4 py-2">Parent</th>
+            <th scope="col" class="px-4 py-2">First Names</th>
+            <th scope="col" class="px-4 py-2">Last Names</th>
+            <th scope="col" class="px-4 py-2">Parents</th>
             <th scope="col" class="px-4 py-2">Partner</th>
             <th scope="col" class="px-4 py-2">Actions</th>
           </tr>
@@ -62,27 +62,27 @@
     <form id="person-form" class="grid gap-4 md:grid-cols-2">
       <input type="hidden" id="person-id" name="id" />
       <div>
-        <label for="first-name" class="block text-sm font-medium">First Name</label>
-        <input id="first-name" name="firstName" type="text" class="mt-1 w-full rounded border border-gray-300" minlength="1" />
+        <label for="first-names" class="block text-sm font-medium">First Names</label>
+        <input id="first-names" name="firstNames" type="text" class="mt-1 w-full rounded border border-gray-300" minlength="1" />
       </div>
       <div>
-        <label for="last-name" class="block text-sm font-medium">Last Name</label>
-        <input id="last-name" name="lastName" type="text" class="mt-1 w-full rounded border border-gray-300" minlength="1" required />
+        <label for="last-names" class="block text-sm font-medium">Last Names</label>
+        <input id="last-names" name="lastNames" type="text" class="mt-1 w-full rounded border border-gray-300" minlength="1" required />
       </div>
       <div>
-        <label for="birth-date" class="block text-sm font-medium">Birthdate</label>
+        <label for="birth-date" class="block text-sm font-medium">Date of Birth</label>
         <input id="birth-date" name="birthDate" type="text" class="mt-1 w-full rounded border border-gray-300" placeholder="YYYY or YYYY-MM or YYYY-MM-DD" pattern="\d{4}(-\d{2}(-\d{2})?)?" inputmode="numeric" maxlength="10" required />
       </div>
       <div>
-        <label for="death-date" class="block text-sm font-medium">Death</label>
+        <label for="death-date" class="block text-sm font-medium">Date of Death</label>
         <input id="death-date" name="deathDate" type="text" class="mt-1 w-full rounded border border-gray-300" placeholder="YYYY or YYYY-MM or YYYY-MM-DD" pattern="\d{4}(-\d{2}(-\d{2})?)?" inputmode="numeric" maxlength="10" />
       </div>
       <div>
-        <label for="birth-place" class="block text-sm font-medium">Birth location</label>
+        <label for="birth-place" class="block text-sm font-medium">Birth Location</label>
         <input id="birth-place" name="birthPlace" type="text" class="mt-1 w-full rounded border border-gray-300" />
       </div>
       <div>
-        <label for="death-place" class="block text-sm font-medium">Death location</label>
+        <label for="death-place" class="block text-sm font-medium">Death Location</label>
         <input id="death-place" name="deathPlace" type="text" class="mt-1 w-full rounded border border-gray-300" />
       </div>
       <div>
@@ -95,8 +95,14 @@
         </select>
       </div>
       <div>
-        <label for="parent-id" class="block text-sm font-medium">Parent</label>
-        <select id="parent-id" name="parentId" class="mt-1 w-full rounded border border-gray-300">
+        <label for="parent1-id" class="block text-sm font-medium">Parent 1</label>
+        <select id="parent1-id" name="parent1Id" class="mt-1 w-full rounded border border-gray-300">
+          <option value="">Select</option>
+        </select>
+      </div>
+      <div>
+        <label for="parent2-id" class="block text-sm font-medium">Parent 2</label>
+        <select id="parent2-id" name="parent2Id" class="mt-1 w-full rounded border border-gray-300">
           <option value="">Select</option>
         </select>
       </div>


### PR DESCRIPTION
## Summary
- rename form labels and table headings to use plural names and clearer date/location wording
- allow two parents per person and show both parents in the table
- update app logic to store and manage two parent selections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e7ca3a7d08331937fb724c67eb4fe