### PR TITLE
refactor: use dialog element for person form

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -6,7 +6,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const emptyBtn = document.getElementById('empty-btn');
   const exportBtn = document.getElementById('export-btn');
   const importBtn = document.getElementById('import-btn');
-  const overlay = document.getElementById('overlay');
   const drawer = document.getElementById('drawer');
   const form = document.getElementById('person-form');
   const cancelBtn = document.getElementById('cancel-btn');
@@ -114,45 +113,20 @@ document.addEventListener('DOMContentLoaded', () => {
       form.reset();
       idInput.value = '';
     }
-    overlay.classList.remove('hidden');
-    overlay.setAttribute('aria-hidden', 'false');
-    drawer.classList.remove('translate-y-full');
+    drawer.showModal();
     firstNamesInput.focus();
   }
 
   function closeDrawer() {
-    overlay.classList.add('hidden');
-    overlay.setAttribute('aria-hidden', 'true');
-    drawer.classList.add('translate-y-full');
-    addBtn.focus();
-  }
-
-  function maskDateInput(e) {
-    let v = e.target.value.replace(/\D/g, '').slice(0, 8);
-    let result = '';
-    if (v.length > 0) {
-      result = v.slice(0, 4);
-      if (v.length > 4) {
-        result += '-' + v.slice(4, 6);
-        if (v.length > 6) {
-          result += '-' + v.slice(6, 8);
-        }
-      }
-    }
-    e.target.value = result;
+    drawer.close();
   }
 
   addBtn.addEventListener('click', openDrawer);
   cancelBtn.addEventListener('click', closeDrawer);
-  overlay.addEventListener('click', closeDrawer);
-  document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') {
-      closeDrawer();
-    }
-  });
 
-  birthDateInput.addEventListener('input', maskDateInput);
-  deathDateInput.addEventListener('input', maskDateInput);
+  drawer.addEventListener('close', () => {
+    addBtn.focus();
+  });
 
   form.addEventListener('submit', e => {
     e.preventDefault();

--- a/web/index.html
+++ b/web/index.html
@@ -56,8 +56,7 @@
     </div>
   </main>
 
-  <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden" aria-hidden="true"></div>
-  <div id="drawer" class="drawer fixed inset-x-0 bottom-0 bg-white rounded-t-lg p-4 transform translate-y-full" role="dialog" aria-modal="true" aria-labelledby="add-person-heading">
+  <dialog id="drawer" class="drawer fixed inset-x-0 bottom-0 bg-white rounded-t-lg p-4" aria-labelledby="add-person-heading">
     <h2 id="add-person-heading" class="text-lg font-semibold mb-4">Add Person</h2>
     <form id="person-form" class="grid gap-4 md:grid-cols-2">
       <input type="hidden" id="person-id" name="id" />
@@ -127,7 +126,7 @@
         </button>
       </div>
     </form>
-  </div>
+  </dialog>
 
   <script src="app.js"></script>
 </body>

--- a/web/style.css
+++ b/web/style.css
@@ -2,3 +2,20 @@
 .drawer {
   transition: transform 0.3s ease-in-out;
 }
+
+dialog.drawer {
+  position: fixed;
+  inset: auto 0 0 0;
+  width: 100%;
+  margin: 0;
+  border: none;
+  transform: translateY(100%);
+}
+
+dialog.drawer[open] {
+  transform: translateY(0);
+}
+
+dialog.drawer::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}


### PR DESCRIPTION
## Summary
- replace custom overlay with native `<dialog>` element for the person form
- rely on HTML pattern attributes for date inputs instead of JS masking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e7e9070888331902685b4b316174d