### PR TITLE
Add zoomable, pannable tree view

### DIFF
--- a/web/app-tree.js
+++ b/web/app-tree.js
@@ -74,7 +74,9 @@ function renderTree(people) {
 
   svg.selectAll('*').remove();
 
-  svg
+  const g = svg.append('g');
+
+  g
     .append('g')
     .attr('fill', 'none')
     .attr('stroke', '#555')
@@ -94,7 +96,7 @@ function renderTree(people) {
       }
     }
   });
-  svg
+  g
     .append('g')
     .attr('stroke', '#1d4ed8')
     .selectAll('line')
@@ -105,11 +107,12 @@ function renderTree(people) {
     .attr('x2', d => d.target.x)
     .attr('y2', d => d.target.y);
 
-  const nodes = svg
+  const nodes = g
     .append('g')
     .selectAll('g')
     .data(root.descendants())
     .join('g')
+    .attr('class', 'person')
     .attr('transform', d => `translate(${d.x},${d.y})`);
 
   nodes
@@ -141,4 +144,14 @@ function renderTree(people) {
       d =>
         `${(d.data.birthDate || '').slice(0, 4)} - ${(d.data.deathDate || '').slice(0, 4)}`
     );
+
+  const zoom = d3
+    .zoom()
+    .scaleExtent([0.5, 2])
+    .filter(event => event.type === 'wheel' || !event.target.closest('.person'))
+    .on('zoom', event => {
+      g.attr('transform', event.transform);
+    });
+
+  svg.call(zoom);
 }

--- a/web/index.html
+++ b/web/index.html
@@ -57,7 +57,9 @@
       </div>
     </section>
     <section class="hidden md:block md:w-1/2">
-      <svg id="tree" class="w-full h-full bg-white rounded shadow" aria-label="Family tree visualization"></svg>
+      <div class="w-full h-full overflow-auto bg-white rounded shadow">
+        <svg id="tree" aria-label="Family tree visualization"></svg>
+      </div>
     </section>
   </main>
 

--- a/web/style.css
+++ b/web/style.css
@@ -19,3 +19,8 @@ dialog.drawer[open] {
 dialog.drawer::backdrop {
   background: rgba(0, 0, 0, 0.5);
 }
+
+/* Tree visualization styles */
+#tree text {
+  font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- allow zooming and panning of the tree while ignoring drag events on person boxes
- render tree inside a scrollable container
- set default tree text to 1rem

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ea0d4ee1c83318946bb3a9a6f8ef8