### PR TITLE
Expand tree canvas to fill chart area

### DIFF
--- a/web/app-tree.js
+++ b/web/app-tree.js
@@ -68,9 +68,10 @@ function renderTree(people) {
 
   const svg = d3
     .select('#tree')
-    .attr('width', width)
-    .attr('height', height)
-    .attr('viewBox', `0 0 ${width} ${height}`);
+    .attr('width', '100%')
+    .attr('height', '100%')
+    .attr('viewBox', `0 0 ${width} ${height}`)
+    .attr('preserveAspectRatio', 'xMidYMid meet');
 
   svg.selectAll('*').remove();
 

--- a/web/style.css
+++ b/web/style.css
@@ -21,6 +21,10 @@ dialog.drawer::backdrop {
 }
 
 /* Tree visualization styles */
+#tree {
+  width: 100%;
+  height: 100%;
+}
 #tree text {
   font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- Scale the family tree SVG to fill its container and maintain aspect ratio
- Ensure the tree canvas occupies the full chart space via CSS

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eca07d98483318e9e2f909045ac20